### PR TITLE
Add function SetKprobeForSection to change section name in module

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -784,10 +784,10 @@ func (b *Module) CloseExt(options map[string]CloseOptions) error {
 	return nil
 }
 
-// UpdateMappingName takes a mapping type which represents one of the mappings that current module stores,
+// UpdateSecName takes a mapping type which represents one of the mappings that current module stores,
 // and update the name on the section object from "oldName" to "newName".
 // Note that this doesn't change the key in the mapping
-func (b *Module) UpdateMappingName(mappingType MappingType, oldName, newName string) error {
+func (b *Module) UpdateSecName(mappingType MappingType, oldName, newName string) error {
 	found := false
 
 	switch mappingType {

--- a/elf/module.go
+++ b/elf/module.go
@@ -774,13 +774,13 @@ func (b *Module) CloseExt(options map[string]CloseOptions) error {
 	return nil
 }
 
-// UpdateKprobeSecName updates the name on the kprobe section object from "oldName" to "newName".
-// Note that this doesn't change the key in the mapping
-func (b *Module) UpdateKprobeSecName(oldName, newName string) error {
-	if sec, ok := b.probes[oldName]; ok {
-		sec.Name = newName
+// UpdateKprobeNameForHandler takes a handler and try to find the corresponding kprobe from a previously loaded mapping,
+// if found then update the kprobe name to "newKprobeName"
+func (b *Module) UpdateKprobeNameForHandler(handler, newKprobeName string) error {
+	if sec, ok := b.probes[handler]; ok {
+		sec.Name = newKprobeName
 	} else {
-		return fmt.Errorf("no such section \"%s\" exists in kprobe mapping", oldName)
+		return fmt.Errorf("no such handler \"%s\" exists in kprobe mapping", handler)
 	}
 	return nil
 }

--- a/elf/module.go
+++ b/elf/module.go
@@ -91,6 +91,19 @@ int bpf_detach_socket(int sock, int fd)
 */
 import "C"
 
+// MappingType is a enum value representing types of mappings the module stores
+type MappingType int
+
+const (
+	TypeMap MappingType = iota
+	TypeProbe
+	TypeUprobe
+	TypeCgroupProgram
+	TypeSocketFilter
+	TypeTracepointProgram
+	TypeSchedProgram
+)
+
 type Module struct {
 	fileName   string
 	fileReader io.ReaderAt
@@ -768,5 +781,58 @@ func (b *Module) CloseExt(options map[string]CloseOptions) error {
 	if err := b.closeSocketFilters(); err != nil {
 		return err
 	}
+	return nil
+}
+
+// UpdateMappingName takes a mapping type which represents one of the mappings that current module stores,
+// and update the name on the section object from "oldName" to "newName".
+// Note that this doesn't change the key in the mapping
+func (b *Module) UpdateMappingName(mappingType MappingType, oldName, newName string) error {
+	found := false
+
+	switch mappingType {
+	case TypeMap:
+		if sec, ok := b.maps[oldName]; ok {
+			sec.Name = newName
+			found = true
+		}
+	case TypeProbe:
+		if sec, ok := b.probes[oldName]; ok {
+			sec.Name = newName
+			found = true
+		}
+	case TypeUprobe:
+		if sec, ok := b.uprobes[oldName]; ok {
+			sec.Name = newName
+			found = true
+		}
+	case TypeCgroupProgram:
+		if sec, ok := b.cgroupPrograms[oldName]; ok {
+			sec.Name = newName
+			found = true
+		}
+	case TypeSocketFilter:
+		if sec, ok := b.socketFilters[oldName]; ok {
+			sec.Name = newName
+			found = true
+		}
+	case TypeTracepointProgram:
+		if sec, ok := b.tracepointPrograms[oldName]; ok {
+			sec.Name = newName
+			found = true
+		}
+	case TypeSchedProgram:
+		if sec, ok := b.schedPrograms[oldName]; ok {
+			sec.Name = newName
+			found = true
+		}
+	default:
+		return fmt.Errorf("no such mapping exists in module: %v", MappingType(mappingType))
+	}
+
+	if !found {
+		return fmt.Errorf("no such section \"%s\" exists in mapping %v", oldName, mappingType)
+	}
+
 	return nil
 }

--- a/elf/module.go
+++ b/elf/module.go
@@ -383,7 +383,7 @@ func (b *Module) EnableKprobes(maxactive int) error {
 			kprobeForSections[kprobe.Name] = section
 		}
 	}
-	for section, kprobe := range b.probes {
+	for section := range b.probes {
 		err = b.EnableKprobe(section, maxactive)
 		if err != nil {
 			return err

--- a/elf/module.go
+++ b/elf/module.go
@@ -372,15 +372,15 @@ func (b *Module) IterKprobes() <-chan *Kprobe {
 // value in maxactive will be applied to all the kretprobes.
 func (b *Module) EnableKprobes(maxactive int) error {
 	var err error
-	// a map to check if there are 2 handlers that are mapping to
+	// a map to check if there are 2 sections that are mapping to
 	// the same kprobe function name. If so, we can't reliably determine
 	// which one to use, so we return an error
-	kprobeForHandlers := map[string]string{}
-	for handler, kprobe := range b.probes {
-		if h, ok := kprobeForHandlers[kprobe.Name]; ok {
-			return fmt.Errorf("found two handlers (%s and %s) mapping to the same kprobe function %s", h, handler, kprobe.Name)
+	kprobeForSections := map[string]string{}
+	for section, kprobe := range b.probes {
+		if h, ok := kprobeForSections[kprobe.Name]; ok {
+			return fmt.Errorf("found two sections (%s and %s) mapping to the same kprobe function %s", h, section, kprobe.Name)
 		} else {
-			kprobeForHandlers[kprobe.Name] = handler
+			kprobeForSections[kprobe.Name] = section
 		}
 	}
 	for _, kprobe := range b.probes {
@@ -785,13 +785,13 @@ func (b *Module) CloseExt(options map[string]CloseOptions) error {
 	return nil
 }
 
-// UpdateKprobeNameForHandler takes a handler and try to find the corresponding kprobe from a previously loaded mapping,
+// SetKprobeForSection takes a section name and try to find the corresponding kprobe from a previously loaded mapping,
 // if found then update the kprobe name to the value of newKprobeName
-func (b *Module) UpdateKprobeNameForHandler(handler, newKprobeName string) error {
-	if sec, ok := b.probes[handler]; ok {
+func (b *Module) SetKprobeForSection(sectionName, newKprobeName string) error {
+	if sec, ok := b.probes[sectionName]; ok {
 		sec.Name = newKprobeName
 	} else {
-		return fmt.Errorf("no such handler \"%s\" exists in kprobe mapping", handler)
+		return fmt.Errorf("no such section name \"%s\" exists in kprobe mapping", sectionName)
 	}
 	return nil
 }

--- a/elf/module.go
+++ b/elf/module.go
@@ -827,7 +827,7 @@ func (b *Module) UpdateSecName(mappingType MappingType, oldName, newName string)
 			found = true
 		}
 	default:
-		return fmt.Errorf("no such mapping exists in module: %v", MappingType(mappingType))
+		return fmt.Errorf("no such mapping exists in module: %v", mappingType)
 	}
 
 	if !found {

--- a/elf/module.go
+++ b/elf/module.go
@@ -372,7 +372,7 @@ func (b *Module) IterKprobes() <-chan *Kprobe {
 // value in maxactive will be applied to all the kretprobes.
 func (b *Module) EnableKprobes(maxactive int) error {
 	var err error
-	// a map to check if there are 2 sections that are mapping to
+	// a map to check if there are 2 sections mapping to
 	// the same kprobe function name. If so, we can't reliably determine
 	// which one to use, so we return an error
 	kprobeForSections := map[string]string{}
@@ -383,8 +383,8 @@ func (b *Module) EnableKprobes(maxactive int) error {
 			kprobeForSections[kprobe.Name] = section
 		}
 	}
-	for _, kprobe := range b.probes {
-		err = b.EnableKprobe(kprobe.Name, maxactive)
+	for section, kprobe := range b.probes {
+		err = b.EnableKprobe(section, maxactive)
 		if err != nil {
 			return err
 		}

--- a/elf/module.go
+++ b/elf/module.go
@@ -338,11 +338,10 @@ func (b *Module) EnableTracepoint(secName string) error {
 		return fmt.Errorf("no such tracepoint program %q", secName)
 	}
 	progFd := prog.fd
-	traceSecName := prog.Name
 
-	tracepointGroup := strings.SplitN(traceSecName, "/", 3)
+	tracepointGroup := strings.SplitN(secName, "/", 3)
 	if len(tracepointGroup) != 3 {
-		return fmt.Errorf("invalid section name %q, expected tracepoint/category/name", traceSecName)
+		return fmt.Errorf("invalid section name %q, expected tracepoint/category/name", secName)
 	}
 	category := tracepointGroup[1]
 	name := tracepointGroup[2]

--- a/elf/module.go
+++ b/elf/module.go
@@ -295,22 +295,24 @@ func (b *Module) EnableOptionCompatProbe() {
 // For kprobes, maxactive is ignored.
 func (b *Module) EnableKprobe(secName string, maxactive int) error {
 	var probeType, funcName string
-	isKretprobe := strings.HasPrefix(secName, "kretprobe/")
 	probe, ok := b.probes[secName]
 	if !ok {
 		return fmt.Errorf("no such kprobe %q", secName)
 	}
+
+	probeSecName := probe.Name
+	isKretprobe := strings.HasPrefix(probeSecName, "kretprobe/")
 	progFd := probe.fd
 	var maxactiveStr string
 	if isKretprobe {
 		probeType = "r"
-		funcName = strings.TrimPrefix(secName, "kretprobe/")
+		funcName = strings.TrimPrefix(probeSecName, "kretprobe/")
 		if maxactive > 0 {
 			maxactiveStr = fmt.Sprintf("%d", maxactive)
 		}
 	} else {
 		probeType = "p"
-		funcName = strings.TrimPrefix(secName, "kprobe/")
+		funcName = strings.TrimPrefix(probeSecName, "kprobe/")
 	}
 	eventName := probeType + funcName
 
@@ -348,10 +350,11 @@ func (b *Module) EnableTracepoint(secName string) error {
 		return fmt.Errorf("no such tracepoint program %q", secName)
 	}
 	progFd := prog.fd
+	traceSecName := prog.Name
 
-	tracepointGroup := strings.SplitN(secName, "/", 3)
+	tracepointGroup := strings.SplitN(traceSecName, "/", 3)
 	if len(tracepointGroup) != 3 {
-		return fmt.Errorf("invalid section name %q, expected tracepoint/category/name", secName)
+		return fmt.Errorf("invalid section name %q, expected tracepoint/category/name", traceSecName)
 	}
 	category := tracepointGroup[1]
 	name := tracepointGroup[2]

--- a/elf/module.go
+++ b/elf/module.go
@@ -274,7 +274,7 @@ func (b *Module) EnableOptionCompatProbe() {
 	b.compatProbe = true
 }
 
-// EnableKprobe enables a kprobe/kretprobe identified by secName.
+// EnableKprobe uses secName to locate a probe, then enables a kprobe/kretprobe identified by probe name.
 // For kretprobes, you can configure the maximum number of instances
 // of the function that can be probed simultaneously with maxactive.
 // If maxactive is 0 it will be set to the default value: if CONFIG_PREEMPT is
@@ -287,20 +287,20 @@ func (b *Module) EnableKprobe(secName string, maxactive int) error {
 		return fmt.Errorf("no such kprobe %q", secName)
 	}
 
-	// use the section name on kprobe object to identify the one to use
-	probeSecName := probe.Name
-	isKretprobe := strings.HasPrefix(probeSecName, "kretprobe/")
+	// use the actual kprobe name on kprobe object to identify the one to use
+	probeName := probe.Name
+	isKretprobe := strings.HasPrefix(probeName, "kretprobe/")
 	progFd := probe.fd
 	var maxactiveStr string
 	if isKretprobe {
 		probeType = "r"
-		funcName = strings.TrimPrefix(probeSecName, "kretprobe/")
+		funcName = strings.TrimPrefix(probeName, "kretprobe/")
 		if maxactive > 0 {
 			maxactiveStr = fmt.Sprintf("%d", maxactive)
 		}
 	} else {
 		probeType = "p"
-		funcName = strings.TrimPrefix(probeSecName, "kprobe/")
+		funcName = strings.TrimPrefix(probeName, "kprobe/")
 	}
 	eventName := probeType + funcName
 
@@ -786,7 +786,7 @@ func (b *Module) CloseExt(options map[string]CloseOptions) error {
 }
 
 // UpdateKprobeNameForHandler takes a handler and try to find the corresponding kprobe from a previously loaded mapping,
-// if found then update the kprobe name to "newKprobeName"
+// if found then update the kprobe name to the value of newKprobeName
 func (b *Module) UpdateKprobeNameForHandler(handler, newKprobeName string) error {
 	if sec, ok := b.probes[handler]; ok {
 		sec.Name = newKprobeName

--- a/elf/module_test.go
+++ b/elf/module_test.go
@@ -6,74 +6,28 @@ import (
 	"testing"
 )
 
-func TestUpdateSecName(t *testing.T) {
+func TestUpdateKprobeSecName(t *testing.T) {
 	module := newModule()
-	module.maps = make(map[string]*Map)
-
-	module.maps["map"] = &Map{Name: "map"}
 	module.probes["probe"] = &Kprobe{Name: "probe"}
-	module.uprobes["uprobe"] = &Uprobe{Name: "uprobe"}
-	module.cgroupPrograms["cgroup"] = &CgroupProgram{Name: "cgroup"}
-	module.socketFilters["socketFilter"] = &SocketFilter{Name: "socketFilter"}
-	module.tracepointPrograms["tracepoint"] = &TracepointProgram{Name: "tracepoint"}
-	module.schedPrograms["schedProgram"] = &SchedProgram{Name: "schedProgram"}
 
 	for _, test := range []struct {
-		mappingType MappingType
-		oldName     string
-		newName     string
-		expected    func() string
+		oldName  string
+		newName  string
+		expected func() string
 	}{
 		{
-			mappingType: TypeMap,
-			oldName:     "map",
-			newName:     "newMap",
-			expected:    func() string { return module.maps["map"].Name },
-		},
-		{
-			mappingType: TypeProbe,
-			oldName:     "probe",
-			newName:     "newProbe",
-			expected:    func() string { return module.probes["probe"].Name },
-		},
-		{
-			mappingType: TypeUprobe,
-			oldName:     "uprobe",
-			newName:     "newUprobe",
-			expected:    func() string { return module.uprobes["uprobe"].Name },
-		},
-		{
-			mappingType: TypeCgroupProgram,
-			oldName:     "cgroup",
-			newName:     "newCgroup",
-			expected:    func() string { return module.cgroupPrograms["cgroup"].Name },
-		},
-		{
-			mappingType: TypeSocketFilter,
-			oldName:     "socketFilter",
-			newName:     "newSocketFilter",
-			expected:    func() string { return module.socketFilters["socketFilter"].Name },
-		},
-		{
-			mappingType: TypeTracepointProgram,
-			oldName:     "tracepoint",
-			newName:     "newTracepoint",
-			expected:    func() string { return module.tracepointPrograms["tracepoint"].Name },
-		},
-		{
-			mappingType: TypeSchedProgram,
-			oldName:     "schedProgram",
-			newName:     "newSchedProgram",
-			expected:    func() string { return module.schedPrograms["schedProgram"].Name },
+			oldName:  "probe",
+			newName:  "newProbe",
+			expected: func() string { return module.probes["probe"].Name },
 		},
 	} {
-		err := module.UpdateSecName(test.mappingType, test.oldName, test.newName)
+		err := module.UpdateKprobeSecName(test.oldName, test.newName)
 		if err != nil {
-			t.Fatalf("error occured while using UpdateMappingName function: %s", err)
+			t.Fatalf("error occured while using UpdateKprobeSecName function: %s", err)
 		}
 
 		if test.expected() != test.newName {
-			t.Fatalf("UpdateMappingName function didn't update correctly, expected: %s, actual value: %s", test.newName, test.expected())
+			t.Fatalf("UpdateKprobeSecName function didn't update correctly, expected: %s, actual value: %s", test.newName, test.expected())
 		}
 	}
 }

--- a/elf/module_test.go
+++ b/elf/module_test.go
@@ -37,6 +37,6 @@ func TestEnableKprobesError(t *testing.T) {
 	module.probes["probe"] = &Kprobe{Name: "probe"}
 	module.probes["another_probe"] = &Kprobe{Name: "probe"}
 	if err := module.EnableKprobes(1); err == nil {
-		t.Fatalf("An error should trigger if two handlers are mapping to a same kprobe function")
+		t.Fatalf("An error should trigger if two sections are mapping to a same kprobe function")
 	}
 }

--- a/elf/module_test.go
+++ b/elf/module_test.go
@@ -1,0 +1,79 @@
+// +build linux
+
+package elf
+
+import (
+	"testing"
+)
+
+func TestUpdateSecName(t *testing.T) {
+	module := newModule()
+	module.maps = make(map[string]*Map)
+
+	module.maps["map"] = &Map{Name: "map"}
+	module.probes["probe"] = &Kprobe{Name: "probe"}
+	module.uprobes["uprobe"] = &Uprobe{Name: "uprobe"}
+	module.cgroupPrograms["cgroup"] = &CgroupProgram{Name: "cgroup"}
+	module.socketFilters["socketFilter"] = &SocketFilter{Name: "socketFilter"}
+	module.tracepointPrograms["tracepoint"] = &TracepointProgram{Name: "tracepoint"}
+	module.schedPrograms["schedProgram"] = &SchedProgram{Name: "schedProgram"}
+
+	for _, test := range []struct {
+		mappingType MappingType
+		oldName     string
+		newName     string
+		expected    func() string
+	}{
+		{
+			mappingType: TypeMap,
+			oldName:     "map",
+			newName:     "newMap",
+			expected:    func() string { return module.maps["map"].Name },
+		},
+		{
+			mappingType: TypeProbe,
+			oldName:     "probe",
+			newName:     "newProbe",
+			expected:    func() string { return module.probes["probe"].Name },
+		},
+		{
+			mappingType: TypeUprobe,
+			oldName:     "uprobe",
+			newName:     "newUprobe",
+			expected:    func() string { return module.uprobes["uprobe"].Name },
+		},
+		{
+			mappingType: TypeCgroupProgram,
+			oldName:     "cgroup",
+			newName:     "newCgroup",
+			expected:    func() string { return module.cgroupPrograms["cgroup"].Name },
+		},
+		{
+			mappingType: TypeSocketFilter,
+			oldName:     "socketFilter",
+			newName:     "newSocketFilter",
+			expected:    func() string { return module.socketFilters["socketFilter"].Name },
+		},
+		{
+			mappingType: TypeTracepointProgram,
+			oldName:     "tracepoint",
+			newName:     "newTracepoint",
+			expected:    func() string { return module.tracepointPrograms["tracepoint"].Name },
+		},
+		{
+			mappingType: TypeSchedProgram,
+			oldName:     "schedProgram",
+			newName:     "newSchedProgram",
+			expected:    func() string { return module.schedPrograms["schedProgram"].Name },
+		},
+	} {
+		err := module.UpdateMappingName(test.mappingType, test.oldName, test.newName)
+		if err != nil {
+			t.Fatalf("error occured while using UpdateMappingName function: %s", err)
+		}
+
+		if test.expected() != test.newName {
+			t.Fatalf("UpdateMappingName function didn't update correctly, expected: %s, actual value: %s", test.newName, test.expected())
+		}
+	}
+}

--- a/elf/module_test.go
+++ b/elf/module_test.go
@@ -67,7 +67,7 @@ func TestUpdateSecName(t *testing.T) {
 			expected:    func() string { return module.schedPrograms["schedProgram"].Name },
 		},
 	} {
-		err := module.UpdateMappingName(test.mappingType, test.oldName, test.newName)
+		err := module.UpdateSecName(test.mappingType, test.oldName, test.newName)
 		if err != nil {
 			t.Fatalf("error occured while using UpdateMappingName function: %s", err)
 		}

--- a/elf/module_test.go
+++ b/elf/module_test.go
@@ -31,3 +31,12 @@ func TestUpdateKprobeNameForHandler(t *testing.T) {
 		}
 	}
 }
+
+func TestEnableKprobesError(t *testing.T) {
+	module := newModule()
+	module.probes["probe"] = &Kprobe{Name: "probe"}
+	module.probes["another_probe"] = &Kprobe{Name: "probe"}
+	if err := module.EnableKprobes(1); err == nil {
+		t.Fatalf("An error should trigger if two handlers are mapping to a same kprobe function")
+	}
+}

--- a/elf/module_test.go
+++ b/elf/module_test.go
@@ -6,28 +6,28 @@ import (
 	"testing"
 )
 
-func TestUpdateKprobeNameForHandler(t *testing.T) {
+func TestSetKprobeForSection(t *testing.T) {
 	module := newModule()
 	module.probes["probe"] = &Kprobe{Name: "probe"}
 
 	for _, test := range []struct {
-		handlerName string
+		sectionName string
 		kprobeName  string
 		actual      func() string
 	}{
 		{
-			handlerName: "probe",
+			sectionName: "probe",
 			kprobeName:  "newProbe",
 			actual:      func() string { return module.probes["probe"].Name },
 		},
 	} {
-		err := module.UpdateKprobeNameForHandler(test.handlerName, test.kprobeName)
+		err := module.SetKprobeForSection(test.sectionName, test.kprobeName)
 		if err != nil {
-			t.Fatalf("error occured while using UpdateKprobeNameForHandler function: %s", err)
+			t.Fatalf("error occured while using SetKprobeForSection function: %s", err)
 		}
 
 		if test.actual() != test.kprobeName {
-			t.Fatalf("UpdateKprobeNameForHandler function didn't update correctly, expected: %s, actual value: %s", test.kprobeName, test.actual())
+			t.Fatalf("SetKprobeForSection function didn't update correctly, expected: %s, actual value: %s", test.kprobeName, test.actual())
 		}
 	}
 }

--- a/elf/module_test.go
+++ b/elf/module_test.go
@@ -6,28 +6,28 @@ import (
 	"testing"
 )
 
-func TestUpdateKprobeSecName(t *testing.T) {
+func TestUpdateKprobeNameForHandler(t *testing.T) {
 	module := newModule()
 	module.probes["probe"] = &Kprobe{Name: "probe"}
 
 	for _, test := range []struct {
-		oldName  string
-		newName  string
-		expected func() string
+		handlerName string
+		kprobeName  string
+		actual      func() string
 	}{
 		{
-			oldName:  "probe",
-			newName:  "newProbe",
-			expected: func() string { return module.probes["probe"].Name },
+			handlerName: "probe",
+			kprobeName:  "newProbe",
+			actual:      func() string { return module.probes["probe"].Name },
 		},
 	} {
-		err := module.UpdateKprobeSecName(test.oldName, test.newName)
+		err := module.UpdateKprobeNameForHandler(test.handlerName, test.kprobeName)
 		if err != nil {
-			t.Fatalf("error occured while using UpdateKprobeSecName function: %s", err)
+			t.Fatalf("error occured while using UpdateKprobeNameForHandler function: %s", err)
 		}
 
-		if test.expected() != test.newName {
-			t.Fatalf("UpdateKprobeSecName function didn't update correctly, expected: %s, actual value: %s", test.newName, test.expected())
+		if test.actual() != test.kprobeName {
+			t.Fatalf("UpdateKprobeNameForHandler function didn't update correctly, expected: %s, actual value: %s", test.kprobeName, test.actual())
 		}
 	}
 }

--- a/elf/module_unsupported.go
+++ b/elf/module_unsupported.go
@@ -47,3 +47,7 @@ func (b *Module) Kprobe(name string) *Kprobe {
 func (b *Module) AttachProgram(cgroupProg *CgroupProgram, cgroupPath string, attachType AttachType) error {
 	return fmt.Errorf("not supported")
 }
+
+func (b *Module) UpdateSecName(secType, oldName, newName string) error {
+	return fmt.Errorf("not supported")
+}

--- a/elf/module_unsupported.go
+++ b/elf/module_unsupported.go
@@ -48,6 +48,6 @@ func (b *Module) AttachProgram(cgroupProg *CgroupProgram, cgroupPath string, att
 	return fmt.Errorf("not supported")
 }
 
-func (b *Module) UpdateKprobeNameForHandler(handler, newKprobeName string) error {
+func (b *Module) SetKprobeForSection(sectionName, newKprobeName string) error {
 	return fmt.Errorf("not supported")
 }

--- a/elf/module_unsupported.go
+++ b/elf/module_unsupported.go
@@ -48,6 +48,6 @@ func (b *Module) AttachProgram(cgroupProg *CgroupProgram, cgroupPath string, att
 	return fmt.Errorf("not supported")
 }
 
-func (b *Module) UpdateSecName(secType, oldName, newName string) error {
+func (b *Module) UpdateKprobeSecName(oldName, newName string) error {
 	return fmt.Errorf("not supported")
 }

--- a/elf/module_unsupported.go
+++ b/elf/module_unsupported.go
@@ -48,6 +48,6 @@ func (b *Module) AttachProgram(cgroupProg *CgroupProgram, cgroupPath string, att
 	return fmt.Errorf("not supported")
 }
 
-func (b *Module) UpdateKprobeSecName(oldName, newName string) error {
+func (b *Module) UpdateKprobeNameForHandler(handler, newKprobeName string) error {
 	return fmt.Errorf("not supported")
 }


### PR DESCRIPTION
Currently gobpf uses the name defined in `SEC()` header of each function to bind to the right eBPF API. This creates some inflexibility when we need two implementations of a certain API. For example:

In kernels later than v4.1.0, `tcp_sendmsg` is defined as
```
int tcp_sendmsg(struct sock *sk, struct msghdr *msg, size_t size)
```

In kernels earlier than v4.1.0, the definition is
```
int tcp_sendmsg(struct kiocb *iocb, struct sock *sk, struct msghdr *msg, size_t size)
```

With the change in this pull request we could override the names in any mappings that are stored in module. This means that we can have a custom name in `SEC()` header but still map the implementation to an API that we want. For instance, `SEC("kprobe/tcp_sendmsg_v2")` can map to `kprobe/tcp_sendmsg` if we call `SetKprobeForSection("tcp_sendmsg_v2", "tcp_sendmsg")`.

When we enable the kprobe later on, just do
```
m.EnableKprobe("kprobe/tcp_sendmsg_v2", maxActive)
```
and underlying probe would bind to `tcp_sendmsg` API correctly.