### PR TITLE
Allow ELF section to be disabled altogether

### DIFF
--- a/bpf_test.go
+++ b/bpf_test.go
@@ -661,3 +661,66 @@ func TestModuleLoadELF(t *testing.T) {
 	checkLookupElement(t, b)
 	checkProgTestRun(t, b)
 }
+
+func TestOptionalLoading(t *testing.T) {
+	var err error
+	kernelVersion, err = elf.CurrentKernelVersion()
+	if err != nil {
+		t.Fatalf("error getting current kernel version: %v", err)
+	}
+
+	dummyELF := "./tests/dummy.o"
+	if kernelVersion > kernelVersion410 {
+		dummyELF = "./tests/dummy-410.o"
+	} else if kernelVersion > kernelVersion48 {
+		dummyELF = "./tests/dummy-48.o"
+	} else if kernelVersion > kernelVersion46 {
+		dummyELF = "./tests/dummy-46.o"
+	}
+
+	var secParams = map[string]elf.SectionParams{
+		"maps/dummy_array_custom": elf.SectionParams{
+			PinPath: filepath.Join("gobpf-test", "testgroup1"),
+		},
+		"socket/dummy": {
+			Disabled: true,
+		},
+	}
+	var closeOptions = map[string]elf.CloseOptions{
+		"maps/dummy_array_custom": elf.CloseOptions{
+			Unpin:   true,
+			PinPath: filepath.Join("gobpf-test", "testgroup1"),
+		},
+	}
+
+	if err := bpffs.Mount(); err != nil {
+		t.Fatalf("error mounting bpf fs: %v", err)
+	}
+
+	b := elf.NewModule(dummyELF)
+	if b == nil {
+		t.Fatal("prog is nil")
+	}
+	if err := b.Load(secParams); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := b.CloseExt(closeOptions); err != nil {
+			t.Fatal(err)
+		}
+		checkPinConfigCleanup(t, []string{"/sys/fs/bpf/gobpf-test/testgroup1"})
+	}()
+
+	// Let's make sure our socket filter was *not* loaded
+	// This is useful when you want to compile a single object file, but disable
+	// certain ELF sections for distributions that don't support certain eBPF programs
+	// Example: socket filters for RedHat/CentOS
+	var socketFilters []*elf.SocketFilter
+	for sf := range b.IterSocketFilter() {
+		socketFilters = append(socketFilters, sf)
+	}
+
+	if len(socketFilters) > 0 {
+		t.Fatal("socket filter dummy was loaded, but it shouldn't.")
+	}
+}

--- a/elf/elf.go
+++ b/elf/elf.go
@@ -477,6 +477,7 @@ type SectionParams struct {
 	SkipPerfMapInitialization bool
 	PinPath                   string // path to be pinned, relative to "/sys/fs/bpf"
 	MapMaxEntries             int    // Used to override bpf map entries size
+	Disabled                  bool   // Used to disable loading an ELF section altogether
 }
 
 // Load loads the BPF programs and BPF maps in the module. Each ELF section
@@ -544,6 +545,9 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			processed[section.Info] = true
 
 			secName := rsection.Name
+			if parameters[secName].Disabled {
+				continue
+			}
 
 			isKprobe := strings.HasPrefix(secName, "kprobe/")
 			isKretprobe := strings.HasPrefix(secName, "kretprobe/")
@@ -677,6 +681,9 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 		}
 
 		secName := section.Name
+		if parameters[secName].Disabled {
+			continue
+		}
 
 		isKprobe := strings.HasPrefix(secName, "kprobe/")
 		isKretprobe := strings.HasPrefix(secName, "kretprobe/")


### PR DESCRIPTION
This PR adds a Disabled field to the elf.SectionParams, allowing certain ELF sections to be completely bypassed and not loaded into the eBPF VM.

The motivation for this is to have a single object file that can be used for different distributions that might or not have support for certain eBPF programs.

For example, we want to be able to disable the ELF section containing socket filters for RH and CentOS kernels which don't support it.