### PR TITLE
Export perf_event_open file descriptor

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -644,6 +644,10 @@ func (kp *Kprobe) Fd() int {
 	return kp.fd
 }
 
+func (kp *Kprobe) Efd() int {
+	return kp.efd
+}
+
 func disableKprobe(eventName string) error {
 	kprobeEventsFileName := "/sys/kernel/debug/tracing/kprobe_events"
 	f, err := os.OpenFile(kprobeEventsFileName, os.O_APPEND|os.O_WRONLY, 0)


### PR DESCRIPTION
Description of the problem
---------------------------

The runtime security module in system-probe needs to unregister a kprobe at runtime. The new eBPF library will handle this gracefully but for now we need to manually close the `perf_event_open` file descriptor of the kprobe before disabling the hook point in `kprobe_events`since the current lib doesn't allow to unregister one specific program at a time.

Proposed solution
------------------

This PR introduces `Kprobe.Detach()` which detaches a kprobe from its hook point, without deleting the eBPF bytecode from the kernel.