### PR TITLE
Customize verifier log size

### DIFF
--- a/elf/module.go
+++ b/elf/module.go
@@ -221,6 +221,13 @@ func NewModule(fileName string) *Module {
 	return module
 }
 
+func NewModuleWithLogSize(fileName string, logSize int) *Module {
+	module := newModule()
+	module.fileName = fileName
+	module.log = make([]byte, logSize)
+	return module
+}
+
 func NewModuleFromReader(fileReader io.ReaderAt) *Module {
 	module := newModule()
 	module.fileReader = fileReader

--- a/elf/module.go
+++ b/elf/module.go
@@ -202,7 +202,10 @@ type XDPProgram struct {
 	fd    int
 }
 
-func newModule() *Module {
+// DefaultVerifierBufferSize is the default size used to initialize the verifier logs buffer
+const DefaultVerifierBufferSize = 524288
+
+func newModule(bufferSize int) *Module {
 	return &Module{
 		probes:             make(map[string]*Kprobe),
 		uprobes:            make(map[string]*Uprobe),
@@ -211,25 +214,31 @@ func newModule() *Module {
 		tracepointPrograms: make(map[string]*TracepointProgram),
 		schedPrograms:      make(map[string]*SchedProgram),
 		xdpPrograms:        make(map[string]*XDPProgram),
-		log:                make([]byte, 524288),
+		log:                make([]byte, bufferSize),
 	}
 }
 
 func NewModule(fileName string) *Module {
-	module := newModule()
+	module := newModule(DefaultVerifierBufferSize)
 	module.fileName = fileName
 	return module
 }
 
 func NewModuleWithLogSize(fileName string, logSize int) *Module {
-	module := newModule()
+	module := newModule(logSize)
 	module.fileName = fileName
 	module.log = make([]byte, logSize)
 	return module
 }
 
 func NewModuleFromReader(fileReader io.ReaderAt) *Module {
-	module := newModule()
+	module := newModule(DefaultVerifierBufferSize)
+	module.fileReader = fileReader
+	return module
+}
+
+func NewModuleFromReaderWithLogSize(fileReader io.ReaderAt, logSize int) *Module {
+	module := newModule(logSize)
 	module.fileReader = fileReader
 	return module
 }

--- a/elf/module.go
+++ b/elf/module.go
@@ -227,7 +227,6 @@ func NewModule(fileName string) *Module {
 func NewModuleWithLogSize(fileName string, logSize int) *Module {
 	module := newModule(logSize)
 	module.fileName = fileName
-	module.log = make([]byte, logSize)
 	return module
 }
 

--- a/elf/module_test.go
+++ b/elf/module_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSetKprobeForSection(t *testing.T) {
-	module := newModule()
+	module := newModule(DefaultVerifierBufferSize)
 	module.probes["probe"] = &Kprobe{Name: "probe"}
 
 	for _, test := range []struct {
@@ -33,7 +33,7 @@ func TestSetKprobeForSection(t *testing.T) {
 }
 
 func TestEnableKprobesError(t *testing.T) {
-	module := newModule()
+	module := newModule(DefaultVerifierBufferSize)
 	module.probes["probe"] = &Kprobe{Name: "probe"}
 	module.probes["another_probe"] = &Kprobe{Name: "probe"}
 	if err := module.EnableKprobes(1); err == nil {


### PR DESCRIPTION
Description of the problem
---------------------------

When the log level of the verifier is set to 1 or more, the verifier will write all its verification steps in the log buffer, even if the program ends up being approved. When the buffer is not big enough, the `bpf` call fails and returns `no space left on device`. On kernel 5.x, the verifier is a lot more verbose than before and some of our programs fail to load.

Proposed solution
------------------

This PR introduces `NewModuleWithLogSize` and `NewModuleFromReaderWithLogSize` which can be used to set the verifier log size above the default hardcoded limit of `524288`.