### PR TITLE
Comment out bpf_attach_uprobe for compatibility with bcc 0.17

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -258,14 +258,17 @@ func (bpf *Module) attachProbe(evName string, attachType uint32, fnName string, 
 func (bpf *Module) attachUProbe(evName string, attachType uint32, path string, addr uint64, fd, pid int) error {
 	evNameCS := C.CString(evName)
 	binaryPathCS := C.CString(path)
-	res, err := C.bpf_attach_uprobe(C.int(fd), attachType, evNameCS, binaryPathCS, (C.uint64_t)(addr), (C.pid_t)(pid))
+	// In bcc 0.17, a new function parameter was added which breaks compatibility with this version of gobpf. Since we
+	// do not currently use DataDog/gobpf to load uprobes and will always use DataDog/ebpf in future project, this piece
+	// of code is breaking compatibility with new installs of bcc for no reason.
+	// res, err := C.bpf_attach_uprobe(C.int(fd), attachType, evNameCS, binaryPathCS, (C.uint64_t)(addr), (C.pid_t)(pid))
 	C.free(unsafe.Pointer(evNameCS))
 	C.free(unsafe.Pointer(binaryPathCS))
 
-	if res < 0 {
-		return fmt.Errorf("failed to attach BPF uprobe: %v", err)
-	}
-	bpf.uprobes[evName] = int(res)
+	//if res < 0 {
+	//	return fmt.Errorf("failed to attach BPF uprobe: %v", err)
+	//}
+	//bpf.uprobes[evName] = int(res)
 	return nil
 }
 


### PR DESCRIPTION
What does this PR do ?
-----------------------

We currently do not use `attachUprobe` nor do we plan on using it in future projects of the `datadog-agent` (since we migrated most eBPF programs to use `DataDog/ebpf` and will migrate the last one [once we have runtime compilation in the agent](https://github.com/DataDog/datadog-agent/pull/6978)).

BCC 0.17 introduces a breaking change in the `bpf_attach_uprobe` function by adding a new argument to the function. We have 2 options, either we upgrade `DataDog/gobpf` to work with bcc 0.17 (but this means that we would have to update our build of libbcc in the agent CI as well), or we simply comment out the function in `DataDog/gobpf`.

Motivation
-----------

Compatibility with bcc 0.17 on recent environments.