### PR TITLE
[Backport] Fix memory corruption when reading PERCPU_XXX maps

### DIFF
--- a/pkg/cpuonline/cpuonline.go
+++ b/pkg/cpuonline/cpuonline.go
@@ -1,0 +1,18 @@
+package cpuonline
+
+import (
+	"io/ioutil"
+
+	"github.com/iovisor/gobpf/pkg/cpurange"
+)
+
+const cpuOnline = "/sys/devices/system/cpu/online"
+
+// Get returns a slice with the online CPUs, for example `[0, 2, 3]`
+func Get() ([]uint, error) {
+	buf, err := ioutil.ReadFile(cpuOnline)
+	if err != nil {
+		return nil, err
+	}
+	return cpurange.ReadCPURange(string(buf))
+}

--- a/pkg/cpupossible/cpupossible.go
+++ b/pkg/cpupossible/cpupossible.go
@@ -1,0 +1,18 @@
+package cpupossible
+
+import (
+	"io/ioutil"
+
+	"github.com/iovisor/gobpf/pkg/cpurange"
+)
+
+const cpuPossible = "/sys/devices/system/cpu/possible"
+
+// Get returns a slice with the online CPUs, for example `[0, 2, 3]`
+func Get() ([]uint, error) {
+	buf, err := ioutil.ReadFile(cpuPossible)
+	if err != nil {
+		return nil, err
+	}
+	return cpurange.ReadCPURange(string(buf))
+}

--- a/pkg/cpurange/cpu_range.go
+++ b/pkg/cpurange/cpu_range.go
@@ -1,15 +1,12 @@
-package cpuonline
+package cpurange
 
 import (
-	"io/ioutil"
 	"strconv"
 	"strings"
 )
 
-const cpuOnline = "/sys/devices/system/cpu/online"
-
 // loosely based on https://github.com/iovisor/bcc/blob/v0.3.0/src/python/bcc/utils.py#L15
-func readCPURange(cpuRangeStr string) ([]uint, error) {
+func ReadCPURange(cpuRangeStr string) ([]uint, error) {
 	var cpus []uint
 	cpuRangeStr = strings.Trim(cpuRangeStr, "\n ")
 	for _, cpuRange := range strings.Split(cpuRangeStr, ",") {
@@ -31,13 +28,4 @@ func readCPURange(cpuRangeStr string) ([]uint, error) {
 		}
 	}
 	return cpus, nil
-}
-
-// Get returns a slice with the online CPUs, for example `[0, 2, 3]`
-func Get() ([]uint, error) {
-	buf, err := ioutil.ReadFile(cpuOnline)
-	if err != nil {
-		return nil, err
-	}
-	return readCPURange(string(buf))
 }

--- a/pkg/cpurange/cpu_range_test.go
+++ b/pkg/cpurange/cpu_range_test.go
@@ -1,4 +1,4 @@
-package cpuonline
+package cpurange
 
 import (
 	"testing"
@@ -57,7 +57,7 @@ func TestGetOnlineCPUs(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		cpus, err := readCPURange(test.data)
+		cpus, err := ReadCPURange(test.data)
 		if test.valid && err != nil {
 			t.Errorf("expected input %q to not return an error but got: %v\n", test.data, err)
 		}


### PR DESCRIPTION
This is a backport of iovisor/gobpf#281.

> When accessing an eBPF map element, `gobpf` currently allocates a slice to store one value of that map.
It then calls `bpf_lookup_elem()` to get the element of the map.
>
> But in the case of `PERCPU_XXX` maps, `bpf_lookup_elem()` writes an *array* of values with as many elements as the number of possible CPUs.
> This led to an out-of-bounds write.